### PR TITLE
some fairly simple fixes to support and evaluate masking of probes

### DIFF
--- a/conumee2/DESCRIPTION
+++ b/conumee2/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: conumee2
 Title: Enhanced copy-number variation analysis using Illumina DNA methylation
     arrays for humans and mice
-Version: 2.1
+Version: 2.1.1
 Author: Bjarne Daenekas, Volker Hovestadt, Marc Zapatka
 Maintainer: Volker Hovestadt <conumee@hovestadt.bio>
 Address: Department of Pediatric Oncology, Dana-Farber Cancer Institute, Boston, USA
@@ -42,4 +42,4 @@ Collate:
 biocViews: CopyNumberVariation, DNAMethylation, MethylationArray, Microarray,
     Normalization, Preprocessing, QualityControl, Software
 VignetteBuilder: knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/conumee2/R/annotation.R
+++ b/conumee2/R/annotation.R
@@ -14,7 +14,7 @@ NULL
 #' @param bin_maxsize numeric. Maximum size of a bin. Merged bins that are larger are filtered out.
 #' @param array_type character. One of \code{450k}, \code{EPIC}, \code{EPICv2}, \code{mouse}. When analyzing data from multiple array types, choose between \code{overlap.1} for 450k and EPIC, \code{overlap.2} for EPIC and EPICv2 or \code{overlap.3} for 450k, EPIC, EPICv2.
 #' @param genome character. This parameter can be set to \code{hg38} when working with EPICv2 data. It will be ignored if \code{array_type = mouse}.
-#' @param features vector. Per default, all unique CpGs on the array are used for the analysis. Please provide a vector with Probe IDs to create a customized set of probes.
+#' @param features vector. Per default (i.e., if left set to NULL), all unique CpGs on the array are used for the analysis. Provide a vector with Probe IDs to instead create a customized set of probes, as for sesame-masked intensities.
 #' @param exclude_regions GRanges object or path to bed file containing genomic regions to be excluded.
 #' @param detail_regions GRanges object or path to bed file containing genomic regions to be examined in detail.
 #' @param chrXY logical. Should chromosome X and Y be included in the analysis?
@@ -26,8 +26,7 @@ NULL
 #' anno
 #' @author Volker Hovestadt \email{conumee@@hovestadt.bio}, Bjarne Daenekas
 #' @export
-CNV.create_anno <- function(bin_minprobes = 15, bin_minsize = 50000, bin_maxsize = 5e+06,
-                            array_type = "450k", genome = "hg19", features = "all", exclude_regions = NULL, detail_regions = NULL, chrXY = FALSE) {
+CNV.create_anno <- function(bin_minprobes = 15, bin_minsize = 50000, bin_maxsize = 5e+06, array_type = "450k", genome = "hg19", features = NULL, exclude_regions = NULL, detail_regions = NULL, chrXY = FALSE) {
   object <- new("CNV.anno")
   object@date <- date()
 
@@ -131,7 +130,7 @@ CNV.create_anno <- function(bin_minprobes = 15, bin_minsize = 50000, bin_maxsize
       probes$EPICv1_Loci <- probes$Methyl450_Loci <- NULL
     }
 
-    if(features == "all"){
+    if(is.null(features)) {
       object@probes <- sort(probes)
       message(" - ", length(object@probes), " probes used")
     }else{

--- a/conumee2/R/annotation.R
+++ b/conumee2/R/annotation.R
@@ -134,6 +134,7 @@ CNV.create_anno <- function(bin_minprobes = 15, bin_minsize = 50000, bin_maxsize
       object@probes <- sort(probes)
       message(" - ", length(object@probes), " probes used")
     }else{
+      features <- intersect(features, names(probes)) # sesame keeps ch probes
       object@probes <- sort(probes[features])
       message(" - ", length(object@probes), " probes used")
     }

--- a/conumee2/R/output.R
+++ b/conumee2/R/output.R
@@ -1113,6 +1113,11 @@ CNV.plotly <- function(x, sample = colnames(x@fit$ratio)[1]){
 }
 
 
+# avoid silly issues with saveRDS for CNV.analysis 
+setMethod("containsOutOfMemoryData", "CNV.analysis",
+          function(object) return(FALSE))
 
 
-
+# avoid silly issues with saveRDS for CNV.anno
+setMethod("containsOutOfMemoryData", "CNV.anno",
+          function(object) return(FALSE))

--- a/conumee2/R/output.R
+++ b/conumee2/R/output.R
@@ -1114,10 +1114,24 @@ CNV.plotly <- function(x, sample = colnames(x@fit$ratio)[1]){
 
 
 # avoid silly issues with saveRDS for CNV.analysis 
-setMethod("containsOutOfMemoryData", "CNV.analysis",
-          function(object) return(FALSE))
+setMethod("containsOutOfMemoryData", "CNV.analysis", 
+          function(object) FALSE)
+setMethod("saveRDS", "CNV.analysis", 
+          function(object, file = "", ascii = FALSE, version = NULL, compress = TRUE, refhook = NULL) {
+            if (containsOutOfMemoryData(object)) warning("Cannot serialize!")
+            base::saveRDS(object, file = file, ascii = ascii, version = version,
+                          compress = compress, refhook = refhook)
+          })
+
 
 
 # avoid silly issues with saveRDS for CNV.anno
-setMethod("containsOutOfMemoryData", "CNV.anno",
-          function(object) return(FALSE))
+setMethod("containsOutOfMemoryData", "CNV.anno", 
+          function(object) FALSE)
+setMethod("saveRDS", "CNV.anno", 
+          function(object, file = "", ascii = FALSE, version = NULL, compress = TRUE, refhook = NULL) {
+            if (containsOutOfMemoryData(object)) warning("Cannot serialize!")
+            base::saveRDS(object, file = file, ascii = ascii, version = version,
+                          compress = compress, refhook = refhook)
+          })
+

--- a/conumee2/man/CNV.create_anno.Rd
+++ b/conumee2/man/CNV.create_anno.Rd
@@ -10,7 +10,7 @@ CNV.create_anno(
   bin_maxsize = 5e+06,
   array_type = "450k",
   genome = "hg19",
-  features = "all",
+  features = NULL,
   exclude_regions = NULL,
   detail_regions = NULL,
   chrXY = FALSE
@@ -27,7 +27,7 @@ CNV.create_anno(
 
 \item{genome}{character. This parameter can be set to \code{hg38} when working with EPICv2 data. It will be ignored if \code{array_type = mouse}.}
 
-\item{features}{vector. Per default, all unique CpGs on the array are used for the analysis. Please provide a vector with Probe IDs to create a customized set of probes.}
+\item{features}{vector. Per default (i.e., if left set to NULL), all unique CpGs on the array are used for the analysis. Provide a vector with Probe IDs to instead create a customized set of probes, as for sesame-masked intensities.}
 
 \item{exclude_regions}{GRanges object or path to bed file containing genomic regions to be excluded.}
 


### PR DESCRIPTION
conclusion: for high-input samples, masking seems to result in poorer results.

also added a couple of fixes so that saveRDS does not fail due to BiocGenerics::saveRDS wrapping it.

[GATA2_covs.csv](https://github.com/user-attachments/files/19371351/GATA2_covs.csv)
[conumee2test.R.txt](https://github.com/user-attachments/files/19371352/conumee2test.R.txt)

![genome_heatmap minfi](https://github.com/user-attachments/assets/7cec65ae-dddc-42c5-8fde-68826d970c8a)
![genome_heatmap sesame masked](https://github.com/user-attachments/assets/b497de95-f74c-429e-8361-33850352252c)
![genome_heatmap sesame unmasked](https://github.com/user-attachments/assets/d6f31f95-871a-4521-a4df-f5a713a56ac4)
